### PR TITLE
Implement SLF4J and Logback for robust logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### logs ###
+/logs

--- a/logs/application.log
+++ b/logs/application.log
@@ -1,0 +1,51 @@
+2025-05-31 09:24:59.372 [background-preinit] INFO  o.h.validator.internal.util.Version - HV000001: Hibernate Validator 8.0.2.Final
+2025-05-31 09:24:59.462 [main] INFO  com.api.ApisApplication - Starting ApisApplication using Java 21.0.7 with PID 3432 (/app/build/classes/java/main started by jules in /app)
+2025-05-31 09:24:59.463 [main] DEBUG com.api.ApisApplication - Running with Spring Boot v3.5.0, Spring v6.2.7
+2025-05-31 09:24:59.464 [main] INFO  com.api.ApisApplication - No active profile set, falling back to 1 default profile: "default"
+2025-05-31 09:25:00.522 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2025-05-31 09:25:00.625 [main] INFO  o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 83 ms. Found 1 JPA repository interface.
+2025-05-31 09:25:01.444 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2025-05-31 09:25:01.471 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2025-05-31 09:25:01.479 [main] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
+2025-05-31 09:25:01.480 [main] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/10.1.41]
+2025-05-31 09:25:01.610 [main] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
+2025-05-31 09:25:01.611 [main] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 2066 ms
+2025-05-31 09:25:01.906 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
+2025-05-31 09:25:02.318 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection conn0: url=jdbc:h2:mem:testdb user=SA
+2025-05-31 09:25:02.322 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
+2025-05-31 09:25:02.408 [main] INFO  o.h.jpa.internal.util.LogHelper - HHH000204: Processing PersistenceUnitInfo [name: default]
+2025-05-31 09:25:02.531 [main] INFO  org.hibernate.Version - HHH000412: Hibernate ORM core version 6.6.15.Final
+2025-05-31 09:25:02.609 [main] INFO  o.h.c.i.RegionFactoryInitiator - HHH000026: Second-level cache disabled
+2025-05-31 09:25:03.223 [main] INFO  o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2025-05-31 09:25:03.310 [main] WARN  org.hibernate.orm.deprecation - HHH90000025: H2Dialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2025-05-31 09:25:03.334 [main] INFO  o.hibernate.orm.connections.pooling - HHH10001005: Database info:
+	Database JDBC URL [Connecting through datasource 'HikariDataSource (HikariPool-1)']
+	Database driver: undefined/unknown
+	Database version: 2.3.232
+	Autocommit mode: undefined/unknown
+	Isolation level: undefined/unknown
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2025-05-31 09:25:04.263 [main] INFO  o.h.e.t.j.p.i.JtaPlatformInitiator - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2025-05-31 09:25:04.293 [main] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2025-05-31 09:25:04.574 [main] WARN  o.s.b.a.o.j.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2025-05-31 09:25:04.965 [main] INFO  o.s.b.a.h.H2ConsoleAutoConfiguration - H2 console available at '/h2-console'. Database available at 'jdbc:h2:mem:testdb'
+2025-05-31 09:25:05.035 [main] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2025-05-31 09:25:05.065 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2025-05-31 09:25:05.075 [main] INFO  com.api.ApisApplication - Started ApisApplication in 6.579 seconds (process running for 7.41)
+2025-05-31 09:25:10.269 [http-nio-8080-exec-1] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2025-05-31 09:25:10.270 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2025-05-31 09:25:10.273 [http-nio-8080-exec-1] INFO  o.s.web.servlet.DispatcherServlet - Completed initialization in 2 ms
+2025-05-31 09:25:10.484 [http-nio-8080-exec-1] INFO  com.api.controller.TaskController - Creating new task with name: Test Task
+2025-05-31 09:25:10.677 [http-nio-8080-exec-1] INFO  com.api.controller.TaskController - Task created successfully with ID: 1
+2025-05-31 09:25:10.798 [http-nio-8080-exec-2] INFO  com.api.controller.TaskController - Attempting to retrieve all tasks
+2025-05-31 09:25:11.052 [http-nio-8080-exec-2] INFO  com.api.controller.TaskController - Retrieved 1 tasks.
+2025-05-31 09:25:11.096 [http-nio-8080-exec-4] INFO  com.api.controller.TaskController - Attempting to retrieve task with ID: 1
+2025-05-31 09:25:11.121 [http-nio-8080-exec-4] INFO  com.api.controller.TaskController - Task found with ID: 1
+2025-05-31 09:25:11.146 [http-nio-8080-exec-5] INFO  com.api.controller.TaskController - Attempting to delete task with ID: 1
+2025-05-31 09:25:11.166 [http-nio-8080-exec-5] INFO  com.api.controller.TaskController - Task deleted successfully with ID: 1
+2025-05-31 09:25:11.190 [SpringApplicationShutdownHook] INFO  o.s.b.w.e.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
+2025-05-31 09:25:11.203 [tomcat-shutdown] INFO  o.s.b.w.e.tomcat.GracefulShutdown - Graceful shutdown complete
+2025-05-31 09:25:11.211 [SpringApplicationShutdownHook] INFO  o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2025-05-31 09:25:11.219 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2025-05-31 09:25:11.223 [SpringApplicationShutdownHook] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Shutdown completed.

--- a/src/main/java/com/api/ApisApplication.java
+++ b/src/main/java/com/api/ApisApplication.java
@@ -1,5 +1,7 @@
 package com.api;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,12 +9,15 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ApisApplication {
 
+  private static final Logger log = LoggerFactory.getLogger(ApisApplication.class);
+
   /**
    * Main entry point for the Spring Boot application.
    *
    * @param args Command line arguments.
    */
   public static void main(String[] args) {
+    log.info("Starting ApisApplication...");
     SpringApplication.run(ApisApplication.class, args);
   }
 }

--- a/src/main/java/com/api/controller/TaskController.java
+++ b/src/main/java/com/api/controller/TaskController.java
@@ -1,6 +1,8 @@
 package com.api.controller;
 
 import com.api.model.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.api.repository.TaskRepository;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/tasks")
 public class TaskController {
 
+  private static final Logger log = LoggerFactory.getLogger(TaskController.class);
   private final TaskRepository taskRepository;
 
   /**
@@ -41,11 +44,14 @@ public class TaskController {
    */
   @PostMapping
   public ResponseEntity<Task> createTask(@RequestBody Task task) {
+    log.info("Creating new task with name: {}", task.getName());
     try {
       Task newTask =
           taskRepository.save(new Task(task.getName(), task.getDescription(), task.isCompleted()));
+      log.info("Task created successfully with ID: {}", newTask.getId());
       return new ResponseEntity<>(newTask, HttpStatus.CREATED);
     } catch (Exception e) {
+      log.error("Error creating task: {}", task.getName(), e);
       return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -57,13 +63,17 @@ public class TaskController {
    */
   @GetMapping
   public ResponseEntity<List<Task>> getAllTasks() {
+    log.info("Attempting to retrieve all tasks");
     try {
       List<Task> tasks = taskRepository.findAll();
       if (tasks.isEmpty()) {
+        log.info("No tasks found.");
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
       }
+      log.info("Retrieved {} tasks.", tasks.size());
       return new ResponseEntity<>(tasks, HttpStatus.OK);
     } catch (Exception e) {
+      log.error("Error retrieving all tasks", e);
       return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -76,11 +86,14 @@ public class TaskController {
    */
   @GetMapping("/{id}")
   public ResponseEntity<Task> getTaskById(@PathVariable("id") long id) {
+    log.info("Attempting to retrieve task with ID: {}", id);
     Optional<Task> taskData = taskRepository.findById(id);
 
     if (taskData.isPresent()) {
+      log.info("Task found with ID: {}", id);
       return new ResponseEntity<>(taskData.get(), HttpStatus.OK);
     } else {
+      log.warn("Task not found with ID: {}", id);
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
   }
@@ -94,6 +107,7 @@ public class TaskController {
    */
   @PutMapping("/{id}")
   public ResponseEntity<Task> updateTask(@PathVariable("id") long id, @RequestBody Task task) {
+    log.info("Attempting to update task with ID: {}", id);
     Optional<Task> taskData = taskRepository.findById(id);
 
     if (taskData.isPresent()) {
@@ -102,11 +116,15 @@ public class TaskController {
       existingTask.setDescription(task.getDescription());
       existingTask.setCompleted(task.isCompleted());
       try {
-        return new ResponseEntity<>(taskRepository.save(existingTask), HttpStatus.OK);
+        taskRepository.save(existingTask);
+        log.info("Task updated successfully with ID: {}", existingTask.getId());
+        return new ResponseEntity<>(existingTask, HttpStatus.OK);
       } catch (Exception e) {
+        log.error("Error updating task with ID: {}", id, e);
         return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
       }
     } else {
+      log.warn("Task not found for update with ID: {}", id);
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
   }
@@ -119,10 +137,13 @@ public class TaskController {
    */
   @DeleteMapping("/{id}")
   public ResponseEntity<HttpStatus> deleteTask(@PathVariable("id") long id) {
+    log.info("Attempting to delete task with ID: {}", id);
     try {
       taskRepository.deleteById(id);
+      log.info("Task deleted successfully with ID: {}", id);
       return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     } catch (Exception e) {
+      log.error("Error deleting task with ID: {}", id, e);
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -134,10 +155,13 @@ public class TaskController {
    */
   @DeleteMapping
   public ResponseEntity<HttpStatus> deleteAllTasks() {
+    log.info("Attempting to delete all tasks");
     try {
       taskRepository.deleteAll();
+      log.info("All tasks deleted successfully.");
       return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     } catch (Exception e) {
+      log.error("Error deleting all tasks", e);
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,9 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
+# Logging Configuration
+logging.config=classpath:logback-spring.xml
+
 # Enable H2 Console
 spring.h2.console.enabled=true
 # Optional: Set a custom path for H2 Console

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,55 @@
+<configuration>
+
+    <property name="LOGS_DIR" value="logs"/>
+    <property name="LOG_FILE_NAME" value="application"/>
+    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS_DIR}/${LOG_FILE_NAME}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${LOGS_DIR}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- keep 30 days' worth of history -->
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+    <!-- Application specific loggers -->
+    <logger name="com.api" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
+    </logger>
+
+    <!-- Spring framework loggers -->
+    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.boot" level="INFO"/>
+    <logger name="org.hibernate" level="INFO"/>
+
+    <!--
+        Centralized Logging Consideration:
+        The file appender (FILE) configured above writes logs to ${LOGS_DIR}/${LOG_FILE_NAME}.log.
+        In a microservices or distributed environment, these log files can be collected by a log shipper
+        (e.g., Filebeat, Fluentd, Promtail) and forwarded to a centralized logging system
+        (e.g., ELK Stack - Elasticsearch, Logstash, Kibana; or Grafana Loki).
+        This allows for aggregated log analysis, searching, and monitoring across multiple services.
+        No changes are needed to the application's logging code itself to integrate with such a system,
+        only deployment-level configuration of the log shipper.
+    -->
+</configuration>


### PR DESCRIPTION
This commit introduces a robust logging setup using SLF4J as the facade and Logback as the implementation, which is the default in Spring Boot.

Key changes:
- Added `src/main/resources/logback-spring.xml` to configure logging:
    - Console appender for development convenience.
    - Rolling file appender (`logs/application.log`) for persistent logs, with daily rollover and a 30-day retention policy.
    - Configured log patterns for clear and informative log entries (timestamp, level, thread, logger, message).
    - Set default root log level to INFO.
    - Set application-specific log level for `com.api` package to DEBUG for more detailed tracing.
- Integrated SLF4J loggers into `ApisApplication.java` to log application startup.
- Integrated SLF4J loggers into `TaskController.java` to log:
    - Entry and exit points of controller methods.
    - Key events like creation, retrieval, update, and deletion of tasks.
    - Payloads and identifiers where appropriate (e.g., task ID, task name).
    - Errors and exceptions caught in try-catch blocks.
- Ensured Spring Boot uses this custom configuration by setting `logging.config=classpath:logback-spring.xml` in `application.properties`.
- Added a comment in `logback-spring.xml` regarding how the file-based logs can be collected by log shippers for future centralized logging solutions (e.g., ELK, Loki).

This logging implementation enhances observability, aids in debugging, and provides a foundation for future centralized logging if the application scales or becomes part of a microservices architecture.